### PR TITLE
Fix up syntax in outbound proxy samples

### DIFF
--- a/content-by-language/bash/outbound-integration.sh
+++ b/content-by-language/bash/outbound-integration.sh
@@ -1,4 +1,4 @@
-curl {VGS_SAMPLE_ECHO_SERVER}/post {IGNORE_SSL_FLAG} \\
+curl {VGS_SAMPLE_ECHO_SERVER}/post --cacert {CERT_LOCATION} \\
   -x {SECURE_PROTOCOL}://{ACCESS_CREDENTIALS}@{VAULT_HOST}:{SECURE_PORT} \\
   -H "Content-type: application/json" \\
   -d '{"account_number": "{ALIAS}"}'

--- a/content-by-language/java/outbound-integration.java
+++ b/content-by-language/java/outbound-integration.java
@@ -45,7 +45,7 @@ public class OutboundIntegration {
         new AuthScope("{VAULT_HOST}", proxyPort),
         new UsernamePasswordCredentials("{USERNAME}", "{PASSWORD}"));
     HttpHost proxy = new HttpHost("{VAULT_HOST}", proxyPort, "https");
-    HttpHost target = new HttpHost("{VGS_SAMPLE_ECHO_SERVER}", 443, "https");
+    HttpHost target = new HttpHost(new URL("{VGS_SAMPLE_ECHO_SERVER}").getHost(), 443, "https");
 
     CloseableHttpClient httpclient = HttpClients.custom()
         .setSSLSocketFactory(getSslConnectionSocketFactory())

--- a/content-by-language/node/outbound-integration.js
+++ b/content-by-language/node/outbound-integration.js
@@ -1,12 +1,13 @@
 const fs = require('fs')
 const tls = require('tls')
 const { curly } = require('node-libcurl')
+const {EOL} = require('os');
 
 const certFilePath = '{CERT_LOCATION}'
 const ca = '/tmp/vgs-outbound-proxy-ca.pem'
-const tlsData = tls.rootCertificates.join('\\n')
+const tlsData = tls.rootCertificates.join(EOL)
 const vgsSelfSigned = fs.readFileSync(certFilePath).toString('utf-8')
-const systemCaAndVgsCa = tlsData+ '\\n' + vgsSelfSigned;
+const systemCaAndVgsCa = tlsData + EOL + vgsSelfSigned;
 fs.writeFileSync(ca, systemCaAndVgsCa)
 
 async function run() {

--- a/content-by-language/node/outbound-integration.js
+++ b/content-by-language/node/outbound-integration.js
@@ -4,9 +4,9 @@ const { curly } = require('node-libcurl')
 
 const certFilePath = '{CERT_LOCATION}'
 const ca = '/tmp/vgs-outbound-proxy-ca.pem'
-const tlsData = tls.rootCertificates.join('\n')
+const tlsData = tls.rootCertificates.join('\\n')
 const vgsSelfSigned = fs.readFileSync(certFilePath).toString('utf-8')
-const systemCaAndVgsCa = tlsData+ '\n' + vgsSelfSigned
+const systemCaAndVgsCa = tlsData+ '\\n' + vgsSelfSigned;
 fs.writeFileSync(ca, systemCaAndVgsCa)
 
 async function run() {

--- a/content-by-language/python/outbound-integration.py
+++ b/content-by-language/python/outbound-integration.py
@@ -1,11 +1,12 @@
 import json
 import tempfile
+import os
 
 import requests # requires requests==2.26.0 and urllib3==1.26.7
 from requests import utils
 
 def send_post_request(url, proxy, payload, headers, ca):
-    return requests.post(url, proxies={{SECURE_PROTOCOL}: proxy},
+    return requests.post(url, proxies={f'{SECURE_PROTOCOL}': proxy},
                          data=json.dumps(payload),
                          headers=headers, verify=ca)
 
@@ -16,7 +17,7 @@ def vgs_proxy():
     path_to_vgs_ca = '{CERT_LOCATION}'
     with tempfile.NamedTemporaryFile() as ca_file:
         ca_file.write(read_file(path_to_vgs_ca))
-        ca_file.write(str.encode('\n'))
+        ca_file.write(str.encode(os.linesep))
         ca_file.write(read_file(path_to_lib_ca))
         read_file(ca_file.name)
         return send_post_request(


### PR DESCRIPTION
- Fix up syntax errors that were introduced when updating outbound proxy snippets
- Avoid insecure option in Curl outbound example